### PR TITLE
Add yfinance-based stock simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ A simple Streamlit app template for you to modify!
    ```
    $ streamlit run streamlit_app.py
    ```
+
+### Simulator
+
+The app now lets you fetch historical prices for a stock or ETF using `yfinance`.
+Enter a ticker symbol and an optional date range. The app downloads daily data,
+calculates daily percentage returns, and then annualizes the mean and standard
+deviation to produce expected return and volatility estimates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 streamlit
+yfinance
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,31 @@
+import datetime as dt
+
 import streamlit as st
+import pandas as pd
+import yfinance as yf
 
 st.title("🎈 My new app")
-st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
+
+ticker = st.text_input("Ticker", "SPY")
+today = dt.date.today()
+default_start = today - dt.timedelta(days=365)
+start, end = st.date_input(
+    "Date range",
+    value=(default_start, today),
 )
+
+expected_return = 0.0
+volatility = 0.0
+
+try:
+    data = yf.download(ticker, start=start, end=end, progress=False)
+    if not data.empty:
+        daily_returns = data["Adj Close"].pct_change().dropna()
+        if not daily_returns.empty:
+            expected_return = float(daily_returns.mean() * 252)
+            volatility = float(daily_returns.std() * (252 ** 0.5))
+except Exception as e:
+    st.warning(f"Data retrieval failed: {e}")
+
+st.write(f"Expected annual return: {expected_return:.2%}")
+st.write(f"Annual volatility: {volatility:.2%}")


### PR DESCRIPTION
## Summary
- add `yfinance` requirement
- compute expected return and volatility of a ticker in `streamlit_app.py`
- document simulator usage in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f5f26ea7483288c9faa66ce88d58d